### PR TITLE
Update calendar.js buildDatePickerMode to keep the picker's correct p…

### DIFF
--- a/dist/calendar.js
+++ b/dist/calendar.js
@@ -752,7 +752,7 @@ function calendarJs(elementOrId, options, searchOptions) {
   }
   function updateDatePickerInputValueDisplay(date) {
     _element_Mode_DatePicker_Input.value = getCustomFormattedDateText(_options.views.datePicker.selectedDateFormat, date);
-    _element_Mode_DatePicker_HiddenInput.value = padNumber(date.getDate()) + "/" + padNumber(date.getMonth()) + "/" + date.getFullYear();
+    _element_Mode_DatePicker_HiddenInput.value = date.getFullYear() + '-' +padNumber(date.getMonth() + 1) + '-' + padNumber(date.getDate());
   }
   function getDataPickerInputValueDate() {
     var values = _element_Mode_DatePicker_HiddenInput.value.split("/");

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -1876,11 +1876,10 @@ function calendarJs( elementOrId, options, searchOptions ) {
         _element_Mode_DatePicker_Input.placeholder = _options.selectDatePlaceholderText;
         _element_Mode_DatePicker_Enabled = true;
 
-        var parent = element.parentNode;
-        parent.removeChild( element );
-
         var container = createElement( "div", "calendar-date-picker" );
-        parent.appendChild( container );
+        element.insertAdjacentElement('afterend', container);
+        element.remove(element);
+     
         container.appendChild( _element_Mode_DatePicker_HiddenInput );
         container.appendChild( _element_Mode_DatePicker_Input );
 

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -1999,7 +1999,7 @@ function calendarJs( elementOrId, options, searchOptions ) {
 
     function updateDatePickerInputValueDisplay( date ) {
         _element_Mode_DatePicker_Input.value = getCustomFormattedDateText( _options.views.datePicker.selectedDateFormat, date );
-        _element_Mode_DatePicker_HiddenInput.value = padNumber( date.getDate() ) + "/" + padNumber( date.getMonth() ) + "/" + date.getFullYear();
+        _element_Mode_DatePicker_HiddenInput.value = padNumber( date.getDate() ) + "/" + padNumber( date.getMonth() - 1 ) + "/" + date.getFullYear();
     }
 
     function getDataPickerInputValueDate() {

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -1937,6 +1937,20 @@ function calendarJs( elementOrId, options, searchOptions ) {
 
         _element_Calendar.style.top = actualTop + "px";
 
+     
+    
+       const formParent = _element_Mode_DatePicker_Input.closest('form');
+       
+       if(formParent) {
+           const calendarLeft = _element_Calendar.offsetLeft;
+           const formLeft = formParent.offsetLeft;
+           if (calendarLeft < formLeft) {
+               _element_Calendar.style.right = "0";
+           } else {
+               _element_Calendar.style.removeProperty("right");
+           }
+       }
+
         var offset = getOffset( _element_Calendar ),
             scrollPosition = getScrollPosition(),
             top = ( offset.top - scrollPosition.top );


### PR DESCRIPTION
Updated buildDatePickerMode function to set the picker readonly input in correct position, current it taking the input last of parent which should not be 