### PR TITLE
Fix links in documentation

### DIFF
--- a/docs/CLASS.md
+++ b/docs/CLASS.md
@@ -9,9 +9,9 @@ The main Calendar.js class.
 <br>
 ***Parameter: elementOrId***: '*Object*' - The ID of the element (or the element itself) that should be used to display the calendar (or input to assign a DatePicker).
 <br>
-***Parameter: options***: '*Object*' - All the configurable options that should be used (refer to ["Options"](OPTIONS.md) documentation for properties).
+***Parameter: options***: '*Object*' - All the configurable options that should be used (refer to ["Options"](configuration/OPTIONS.md) documentation for properties).
 <br>
-***Parameter: searchOptions***: '*Object*' - All the configurable search options that should be used (refer to ["Search Options"](SEARCH_OPTIONS.md) documentation for properties).
+***Parameter: searchOptions***: '*Object*' - All the configurable search options that should be used (refer to ["Search Options"](configuration/SEARCH_OPTIONS.md) documentation for properties).
 <br>
 ***Returns***: '*Object*' - The Calendar.js instance.
 

--- a/docs/EVENT.md
+++ b/docs/EVENT.md
@@ -1,6 +1,6 @@
 # Calendar.js - Event:
 
-Below is the format that is expected for an event object when calling "addEvents()", "addEvent()", "updateEvents()", "updateEvent()", and "setEvents()".  Events can also be added on startup via the "Options" ([see](OPTIONS.md)).
+Below is the format that is expected for an event object when calling "addEvents()", "addEvent()", "updateEvents()", "updateEvent()", and "setEvents()".  Events can also be added on startup via the "Options" ([see](configuration/OPTIONS.md)).
 <br>
 <br>
 

--- a/docs/PUBLIC_FUNCTIONS.md
+++ b/docs/PUBLIC_FUNCTIONS.md
@@ -425,7 +425,7 @@ Sets the specific options that should be used.
 <br>
 ***Fires***:  onOptionsUpdated
 <br>
-***Parameter: newOptions***: '*Options*' - All the options that should be set (refer to ["Options"](OPTIONS.md) documentation for properties).
+***Parameter: newOptions***: '*Options*' - All the options that should be set (refer to ["Options"](configuration/OPTIONS.md) documentation for properties).
 <br>
 ***Parameter: [triggerEvent]***: '*boolean*' - States if the "onOptionsUpdated" event should be triggered (defaults to true).
 <br>
@@ -436,7 +436,7 @@ Sets the specific search options that should be used.
 <br>
 ***Fires***:  onSearchOptionsUpdated
 <br>
-***Parameter: newSearchOptions***: '*Search*' - All the search options that should be set (refer to ["Search Options"](SEARCH_OPTIONS.md) documentation for properties).
+***Parameter: newSearchOptions***: '*Search*' - All the search options that should be set (refer to ["Search Options"](configuration/SEARCH_OPTIONS.md) documentation for properties).
 <br>
 ***Parameter: [triggerEvent]***: '*boolean*' - States if the "onSearchOptionsUpdated" event should be triggered (defaults to true).
 <br>


### PR DESCRIPTION
Note that VSCode seems to successfully open `[file](file.md)` when `file.md` is actually located in `path-to-current-markdown-file/subdirectory/file.md`.