### PR TITLE
Update pointer to onBeforeEventAddEdit in calendar.js

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -6106,7 +6106,7 @@ function calendarJs( elementOrId, options, searchOptions ) {
     }
 
     function showEventEditingDialog( eventDetails, overrideTodayDate, overrideTimeValues, originDayDate ) {
-        if ( isFunction( _options.onBeforeEventAddEdit ) ) {
+        if ( isFunction( _options.events.onBeforeEventAddEdit ) ) {
             fireCustomTrigger( _options.events.onBeforeEventAddEdit, eventDetails );
         } else {
             


### PR DESCRIPTION
When setting the custom callback onBeforeEventAddEdit from the calendar options, the callback should be inside events object.